### PR TITLE
Players can now FlipY in videos

### DIFF
--- a/src/main/java/team/creative/littleframes/common/block/TileEntityCreativeFrame.java
+++ b/src/main/java/team/creative/littleframes/common/block/TileEntityCreativeFrame.java
@@ -165,7 +165,7 @@ public class TileEntityCreativeFrame extends TileEntityCreative implements ITick
         nbt.setBoolean("visibleFrame", visibleFrame);
         nbt.setBoolean("bothSides", bothSides);
         nbt.setBoolean("flipX", flipX);
-        nbt.setBoolean("flipX", flipX);
+        nbt.setBoolean("flipY", flipY);
         nbt.setFloat("alpha", alpha);
         nbt.setFloat("brightness", brightness);
         
@@ -192,7 +192,7 @@ public class TileEntityCreativeFrame extends TileEntityCreative implements ITick
         visibleFrame = nbt.getBoolean("visibleFrame");
         bothSides = nbt.getBoolean("bothSides");
         flipX = nbt.getBoolean("flipX");
-        flipX = nbt.getBoolean("flipX");
+        flipY = nbt.getBoolean("flipY");
         if (nbt.hasKey("alpha"))
             alpha = nbt.getFloat("alpha");
         else


### PR DESCRIPTION
Currently in the GUI, when the user clicks in flipY, then clicks in save, the video doesn't flip in Y.  

After this PR, image is flipped in Y correctly. This change relies on the fact that getBoolean returns false if flipY doesn't exist.   

I tested this PR in game:
1. Place a local video.
2. Click in flipY.
3. Click in save.
4. Verify it works as expected.  
